### PR TITLE
adjust ticket and company association query params to csv

### DIFF
--- a/lib/hubspot/codegen/crm/companies/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/companies/api/basic_api.rb
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters

--- a/lib/hubspot/codegen/crm/tickets/api/basic_api.rb
+++ b/lib/hubspot/codegen/crm/tickets/api/basic_api.rb
@@ -194,7 +194,7 @@ module Hubspot
           query_params = opts[:query_params] || {}
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
           query_params[:'idProperty'] = opts[:'id_property'] if !opts[:'id_property'].nil?
 
@@ -270,7 +270,7 @@ module Hubspot
           query_params[:'after'] = opts[:'after'] if !opts[:'after'].nil?
           query_params[:'properties'] = @api_client.build_collection_param(opts[:'properties'], :csv) if !opts[:'properties'].nil?
           query_params[:'propertiesWithHistory'] = @api_client.build_collection_param(opts[:'properties_with_history'], :multi) if !opts[:'properties_with_history'].nil?
-          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :multi) if !opts[:'associations'].nil?
+          query_params[:'associations'] = @api_client.build_collection_param(opts[:'associations'], :csv) if !opts[:'associations'].nil?
           query_params[:'archived'] = opts[:'archived'] if !opts[:'archived'].nil?
 
           # header parameters


### PR DESCRIPTION
Adjusted the ticket and company association query_params to be :csv in order to receive associations when using the basic_api for tickets and companies.